### PR TITLE
Add a function to download the entire catalogue

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -78,6 +78,12 @@ ATNF catalogue, the value of which is printed in the above example.
    the catalogue <http://www.atnf.csiro.au/research/pulsar/psrcat/download.html>`_ and query it with the ``psrcat`` software
    provided.
 
+A function, :func:`~psrqpy.utils.get_catalogue`, is also available to download the entire catalogue and return it as an
+:class:`astropy.table.Table`. This function is heavily based on
+`code <https://github.com/astrophysically/ATNF-Pulsar-Cat/blob/master/ATNF.ipynb>`_ by Joshua Tan
+(`@astrophysically <https://github.com/astrophysically/>`_). The function currently does not return parameter uncertainties
+or references in the table.
+
 More complex queries
 --------------------
 

--- a/psrqpy/__init__.py
+++ b/psrqpy/__init__.py
@@ -2,7 +2,7 @@
 
 """ A Python tool for interacting with the ATNF pulsar catalogue """
 
-__version__ = "0.4.3"
+__version__ = "0.4.4"
 
 from .search import QueryATNF
 from .pulsar import Pulsar, Pulsars

--- a/psrqpy/config.py
+++ b/psrqpy/config.py
@@ -8,6 +8,7 @@ import itertools
 ATNF_VERSION = '1.57' #: the default ATNF catalogue version
 ATNF_BASE_URL = r'http://www.atnf.csiro.au/people/pulsar/psrcat/' #: the ATNF pulsar catalogue base URL
 ATNF_URL = ATNF_BASE_URL + r'proc_form.php?version={version}' #: the ATNF pulsar catalogue base URL for queries
+ATNF_TARBALL = ATNF_BASE_URL + r'downloads/psrcat_pkg.tar.gz' #: name of the tarball containing the entire catalogue database
 
 PARAMS_QUERY = r'{params}'
 USERDEFINED_QUERY = r'&startUserDefined=true&c1_val=&c2_val=&c3_val=&c4_val='

--- a/psrqpy/search.py
+++ b/psrqpy/search.py
@@ -1003,3 +1003,4 @@ class QueryATNF(object):
 
         # return the figure
         return fig
+


### PR DESCRIPTION
A function, `get_catalogue()`, has been added that downloads the entire ATNF catalogue database and returns it as an astropy table. This currently does not return the parameter errors. This function is based on
the code in [ATNF.ipynb](https://github.com/astrophysically/ATNF-Pulsar-Cat/blob/master/ATNF.ipynb) by @astrophysically.

@astrophysically - are you happy for me to use this code? I've added an attribution to you in the code documentation, but I can add you to the copyright statement as well if you want?

See also comment in #3.