### PR TITLE
Remove use of urllib2

### DIFF
--- a/psrqpy/__init__.py
+++ b/psrqpy/__init__.py
@@ -2,7 +2,7 @@
 
 """ A Python tool for interacting with the ATNF pulsar catalogue """
 
-__version__ = "0.4.9"
+__version__ = "0.4.10"
 
 from .search import QueryATNF
 from .pulsar import Pulsar, Pulsars

--- a/psrqpy/utils.py
+++ b/psrqpy/utils.py
@@ -12,7 +12,7 @@ import requests
 from bs4 import BeautifulSoup
 
 from six import string_types
-from six import StringIO
+from six import BytesIO
 
 from .config import ATNF_BASE_URL, ATNF_VERSION, ADS_URL, ATNF_TARBALL, PSR_ALL, PSR_ALL_PARS
 
@@ -35,11 +35,6 @@ def get_catalogue():
         At the moment this function does not return a table that includes the uncertainties on the
         parameters.
     """
-    
-    try:
-        import urllib2
-    except ImportError:
-        raise ImportError('Problem importing urllib2')
 
     try:
         import tarfile
@@ -53,8 +48,8 @@ def get_catalogue():
 
     # get the tarball
     try:
-        pulsargzfile = urllib2.urlopen(ATNF_TARBALL)
-        fp = StringIO(pulsargzfile.read()) # download and store in memory
+        pulsargzfile = requests.get(ATNF_TARBALL)
+        fp = BytesIO(pulsargzfile.content) # download and store in memory
     except IOError:
         raise IOError('Problem accessing ATNF catalogue tarball')
 
@@ -527,7 +522,6 @@ def label_line(ax, line, label, color='k', fs=14, frachoffset=0.1):
         fs (int): the font size for the label text. Defaults to 14.
         frachoffset (float): a number between 0 and 1 giving the fractional offset of the label
             text along the x-axis. Defaults to 0.1, i.e. 10%.
-
 
     Returns:
         :class:`matplotlib.text.Text`: an object containing the label information


### PR DESCRIPTION
In the `get_catalogue()` function it uses urllib2 to download the ATNF catalogue tarball. However, this does not work for Python3, which no longer has urllib2. I've therefore changed to using the requests module instead. In Python3 the tarball content also has to be read as a BytesIO type rather than a StringIO type, so I've also fixed this.