### PR TITLE
Fix get_catalogue()

### DIFF
--- a/psrqpy/__init__.py
+++ b/psrqpy/__init__.py
@@ -2,7 +2,7 @@
 
 """ A Python tool for interacting with the ATNF pulsar catalogue """
 
-__version__ = "0.4.10"
+__version__ = "0.4.11"
 
 from .search import QueryATNF
 from .pulsar import Pulsar, Pulsars

--- a/psrqpy/utils.py
+++ b/psrqpy/utils.py
@@ -71,7 +71,7 @@ def get_catalogue():
     
     # loop through lines in dbfile
     for line in dbfile.readlines():
-        dataline = line.split()   # Splits on whitespace
+        dataline = line.decode().split()   # Splits on whitespace
 
         if dataline[0][0] == commentstring:
             continue

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,11 @@ if sys.argv[-1] == 'publish':
     os.system('twine upload dist/*')
     sys.exit()
 
+if sys.argv[-1] == 'testpublish':
+    os.system('python setup.py sdist bdist_wheel --universal')
+    os.system('twine upload --repository-url https://test.pypi.org/legacy/ dist/*')
+    sys.exit()
+
 setup(name="psrqpy",
       version=VERSION,
       author="Matthew Pitkin",


### PR DESCRIPTION
After PR #16  `get_catalogue()` would still not work under Python 3 due to the strings being read in as byte types, and astropy's Table not liking this. I now decode the bytes to strings and it works.

On a separate note, I've added the ability to publish a test package to the [PyPI testing site](https://test.pypi.org/).