### PR TITLE
Add labels by default

### DIFF
--- a/psrqpy/search.py
+++ b/psrqpy/search.py
@@ -737,7 +737,7 @@ class QueryATNF(object):
     def ppdot(self, intrinsicpdot=False, excludeGCs=False, showtypes=[], showGCs=False,
               showSNRs=False, markertypes={}, deathline=True, deathmodel='Ip', filldeath=True,
               filldeathtype={}, showtau=True, brakingidx=3, tau=None, showB=True, Bfield=None,
-              rcparams={}):
+              pdotlims=None, periodlims=None, rcparams={}):
         """
         Draw a lovely period vs period derivative diagram.
 
@@ -774,6 +774,8 @@ class QueryATNF(object):
                 shows lines for :math:`10^{10}` through to :math:`10^{14}` gauss with steps in
                 powers of 10.
             Bfield (list): a list of magnetic field strengths to plot.
+            periodlims (array_like): the [min, max] period limits to plot with
+            pdotlims (array_like): the [min, max] pdot limits to plot with
             rcparams (dict): a dictionary of :py:obj:`matplotlib.rcParams` setup parameters for the
                 plot.
 
@@ -901,8 +903,10 @@ class QueryATNF(object):
         ax.set_ylabel(r'Period Derivative')
 
         # get limits
-        periodlims = [10**np.floor(np.min(np.log10(periods))), 10.*int(np.ceil(np.max(pdots)/10.))]
-        pdotlims = [10**np.floor(np.min(np.log10(pdots))), 10**np.ceil(np.max(np.log10(pdots)))]
+        if periodlims is None:
+            periodlims = [10**np.floor(np.min(np.log10(periods))), 10.*int(np.ceil(np.max(pdots)/10.))]
+        if pdotlims is None:
+            pdotlims = [10**np.floor(np.min(np.log10(pdots))), 10**np.ceil(np.max(np.log10(pdots)))]
         ax.set_xlim(periodlims);
         ax.set_ylim(pdotlims);
 

--- a/psrqpy/search.py
+++ b/psrqpy/search.py
@@ -976,7 +976,9 @@ class QueryATNF(object):
                     markertypes[thistype]['markerfacecolor'] = 'none'
                 if 'linestyle' not in markertypes[thistype]:
                     markertypes[thistype]['linestyle'] = 'none'
-                typehandle, = ax.loglog(periods[typeidx], pdots[typeidx], **markertypes[thistype])
+                typehandle, = ax.loglog(periods[typeidx], pdots[typeidx],
+                                        label=typelegstring[thistype],
+                                        **markertypes[thistype])
                 if thistype in typelegstring:
                     handles[typelegstring[thistype]] = typehandle
                 else:


### PR DESCRIPTION
Note, this includes the other PR I submitted. So (if that gets accepted) this is just for the second commit, which changes lines 979 to 981 (just adds in the labels). 

Rational:
For the specially plotted pulsars (i.e. Binary, Pulsar Thermal X-ray)
etc, adds the label. This is subsequently overwritten by the ax.legend
call. However, if someone then adds other objects to the figure
generated by psrqpy, this ensures they are saved in the
`legend_handles_labels()` attribute.