### PR TITLE
Add citation information

### DIFF
--- a/psrqpy/__init__.py
+++ b/psrqpy/__init__.py
@@ -4,6 +4,20 @@
 
 __version__ = "0.4.12"
 
+__citation__ = """@article{psrqpy,
+  author = {{Pitkin}, M.},
+   title = "{psrqpy: a python interface for querying the ATNF pulsar catalogue}",
+  volume = 3,
+  number = 22,
+   pages = 538,
+   month = feb,
+    year = 2018,
+ journal = "{Journal of Open Source Software}",
+     doi = {10.21105/joss.00538},
+     url = {https://doi.org/10.21105/joss.00538}
+}
+"""
+
 from .search import QueryATNF
 from .pulsar import Pulsar, Pulsars
 from .utils import *


### PR DESCRIPTION
Add software citation information into the package itself (see, e.g. slide 31 of [this presentation](https://speakerdeck.com/arfon/how-to-get-and-give-career-credit-for-software) by @arfon).