### PR TITLE
search.py: fix missing legend labels

### DIFF
--- a/psrqpy/search.py
+++ b/psrqpy/search.py
@@ -946,6 +946,8 @@ class QueryATNF(object):
         typelegstring['BINARY'] = r'Binary'
         typelegstring['HE'] = r'Radio-IR Emission'
         typelegstring['GC'] = r'Globular Cluster'
+        typelegstring['SNR'] = r'SNR'
+        typelegstring['RRAT'] = r'RRAT'
 
         # show globular cluster pulsars
         if showGCs and not excludeGCs:


### PR DESCRIPTION
Re-adds missing SNR (and RRAT) label from #22.