### PR TITLE
Changes to `get_catalogue` to speed it up significantly

### DIFF
--- a/psrqpy/utils.py
+++ b/psrqpy/utils.py
@@ -158,7 +158,6 @@ def get_catalogue(path_to_db=None):
                 if dataline[0]+'_REF' not in formats.keys():
                     formats[dataline[0]+'_REF'] = np.unicode
 
-    #psrtable.remove_row(ind)  # Final breakstring comes at the end of the file
     del psrlist[-1]  # Final breakstring comes at the end of the file
 
     # add RA and DEC in degs and JNAME/BNAME


### PR DESCRIPTION
I've changed the `get_catalogue()` function to significantly speed it up. Rather than initially creating an astropy table and having to continuously update the number of rows and masked columns, it now just creates a list of dictionaries and uses these to create a table at the end.

@respiewak - would you be able to check this out? It should be flexible enough to read in a database with arbitrary additional parameter values.