### PR TITLE
Add requirements.txt file to MANIFEST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(name="psrqpy",
           readfile(os.path.join(os.path.dirname(__file__), "README.md")),
       install_requires=\
           readfile(os.path.join(os.path.dirname(__file__), "requirements.txt")),
+      include_package_data=True,
       classifiers=[
           "Programming Language :: Python :: 2.7",
           "Programming Language :: Python :: 3.5",


### PR DESCRIPTION
The `requirements.txt` file should be included in the package data, so this PR adds it.