### PR TITLE
Set minimum versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ beautifulsoup4
 numpy
 scipy
 pandas>0.13
-astropy<3.0; python_version <= '2.7'
-astropy; python_version > '3.4'
+astropy>=2.0,<3.0; python_version <= '2.7'
+astropy>=2.0; python_version > '3.4'

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ requests
 beautifulsoup4
 numpy
 scipy
-pandas>0.13
+pandas>0.21
 astropy>=2.0,<3.0; python_version <= '2.7'
 astropy>=2.0; python_version > '3.4'


### PR DESCRIPTION
[`GM_sun` was added in astropy 2.0](https://github.com/astropy/astropy/blob/8d97a4f9d62a76629ac9b86ebd1c22c340ea7a0e/CHANGES.rst#astropyconstants-7) and is required for `psrqpy` to import successfully.

[`pandas 0.21.0` is required for `Series.isna`](https://pandas.pydata.org/pandas-docs/stable/whatsnew/v0.21.0.html#na-naming-changes).