### PR TITLE
Set default for astropy galactocentric coordinates

### DIFF
--- a/psrqpy/search.py
+++ b/psrqpy/search.py
@@ -38,11 +38,12 @@ else:
     from astropy.coordinates import BarycentricTrueEcliptic as BarycentricMeanEcliptic
     ASTROPY_V32 = False
 
+
 # set default astropy galactocentric frame values
 # (https://docs.astropy.org/en/latest/coordinates/galactocentric.html)
 if version.parse(astropy.__version__) >= version.parse("4.0"):
     from astropy.coordinates import galactocentric_frame_defaults
-    _ = galactocentric_frame_defaults.set("pre-v4.0") 
+    _ = galactocentric_frame_defaults.set("pre-v4.0")
 
 
 class QueryATNF(object):

--- a/psrqpy/search.py
+++ b/psrqpy/search.py
@@ -38,6 +38,12 @@ else:
     from astropy.coordinates import BarycentricTrueEcliptic as BarycentricMeanEcliptic
     ASTROPY_V32 = False
 
+# set default astropy galactocentric frame values
+# (https://docs.astropy.org/en/latest/coordinates/galactocentric.html)
+if version.parse(astropy.__version__) >= version.parse("4.0"):
+    from astropy.coordinates import galactocentric_frame_defaults
+    _ = galactocentric_frame_defaults.set("pre-v4.0") 
+
 
 class QueryATNF(object):
     """


### PR DESCRIPTION
I've chosen to use the `pre-v4.0` defaults.

Closes #63.