### PR TITLE
Propagate errors on ecliptical coordinates to equatorial (Fixes #89)

### DIFF
--- a/psrqpy/search.py
+++ b/psrqpy/search.py
@@ -1303,14 +1303,8 @@ class QueryATNF(object):
         self.update(RAJnew, name='RAJ')
         self.update(DECJnew, name='DECJ')
 
-        if 'ELONG_ERR' in self.columns:
-            ELONG_ERR = self.catalogue['ELONG_ERR']
-        else:
-            ELONG_ERR = np.full(self.catalogue_len, np.nan) * aunits.deg
-        if 'ELAT_ERR' in self.columns:
-            ELAT_ERR = self.catalogue['ELAT_ERR']
-        else:
-            ELAT_ERR = np.full(self.catalogue_len, np.nan) * aunits.deg
+        ELONG_ERR = self.catalogue['ELONG_ERR']
+        ELAT_ERR = self.catalogue['ELAT_ERR']
         RAJD_ERRnew = np.full(self.catalogue_len, np.nan)
         DECJD_ERRnew = np.full(self.catalogue_len, np.nan)
         RAJ_ERRnew = np.full(self.catalogue_len, np.nan)

--- a/psrqpy/search.py
+++ b/psrqpy/search.py
@@ -1306,11 +1306,11 @@ class QueryATNF(object):
         if 'ELONG_ERR' in self.columns:
             ELONG_ERR = self.catalogue['ELONG_ERR']
         else:
-            ELONG_ERR = np.full(self.catalogue_len, np.nan)
+            ELONG_ERR = np.full(self.catalogue_len, np.nan) * aunits.deg
         if 'ELAT_ERR' in self.columns:
             ELAT_ERR = self.catalogue['ELAT_ERR']
         else:
-            ELAT_ERR = np.full(self.catalogue_len, np.nan)
+            ELAT_ERR = np.full(self.catalogue_len, np.nan) * aunits.deg
         RAJD_ERRnew = np.full(self.catalogue_len, np.nan)
         DECJD_ERRnew = np.full(self.catalogue_len, np.nan)
         RAJ_ERRnew = np.full(self.catalogue_len, np.nan)

--- a/psrqpy/search.py
+++ b/psrqpy/search.py
@@ -1303,8 +1303,14 @@ class QueryATNF(object):
         self.update(RAJnew, name='RAJ')
         self.update(DECJnew, name='DECJ')
 
-        ELONG_ERR = self.catalogue['ELONG_ERR']
-        ELAT_ERR = self.catalogue['ELAT_ERR']
+        if 'ELONG_ERR' in self.columns:
+            ELONG_ERR = self.catalogue['ELONG_ERR']
+        else:
+            ELONG_ERR = np.full(self.catalogue_len, np.nan)
+        if 'ELAT_ERR' in self.columns:
+            ELAT_ERR = self.catalogue['ELAT_ERR']
+        else:
+            ELAT_ERR = np.full(self.catalogue_len, np.nan)
         RAJD_ERRnew = np.full(self.catalogue_len, np.nan)
         DECJD_ERRnew = np.full(self.catalogue_len, np.nan)
         RAJ_ERRnew = np.full(self.catalogue_len, np.nan)
@@ -1323,16 +1329,16 @@ class QueryATNF(object):
         eracosdec, edec = np.abs(elcosb * cq - eb * sq), np.abs(elcosb * sq + eb * cq)
         era = eracosdec / np.cos(sc.dec.radian)
 
-        RAJD_ERRnew[idx] = era 
+        RAJD_ERRnew[idx] = era
         DECJD_ERRnew[idx] = edec
         RAJ_ERRnew[idx] = 3600 * era / 15
         DECJ_ERRnew[idx] = 3600 * edec
-        
+
         self.update(RAJD_ERRnew, name='RAJD_ERR')
         self.update(DECJD_ERRnew, name='DECJD_ERR')
         self.update(RAJ_ERRnew, name='RAJ_ERR')
         self.update(DECJ_ERRnew, name='DECJ_ERR')
-                
+
         # set references
         if 'ELONG_REF' in self.columns:
             RAJREFnew = np.full(self.catalogue_len, '', dtype='U32')

--- a/psrqpy/search.py
+++ b/psrqpy/search.py
@@ -1320,7 +1320,7 @@ class QueryATNF(object):
             # (Jean Meeus, Astronomal Algorithms, 2nd edition, p. 100)
             ecl = 23.4392911 * aunits.deg
             l, b = ELONG.values[idxerr] * aunits.deg, ELAT.values[idxerr] * aunits.deg
-            el, eb = ELONG_ERR.values[idxerr], ELAT_ERR.values[idxerr]
+            el, eb = ELONG_ERR[idxerr], ELAT_ERR[idxerr]
             elcosb = el * np.cos(b)
             q = np.arctan2(
                 np.cos(l) * np.tan(ecl),

--- a/psrqpy/search.py
+++ b/psrqpy/search.py
@@ -1289,9 +1289,10 @@ class QueryATNF(object):
         idx = np.isfinite(ELONG) & np.isfinite(ELAT)
 
         # get sky coordinates
-        sc = BarycentricMeanEcliptic(ELONG.values[idx]*aunits.deg,
-                                     ELAT.values[idx]*aunits.deg
-                                     ).transform_to(ICRS())
+        sc = BarycentricMeanEcliptic(
+            ELONG.values[idx]*aunits.deg,
+            ELAT.values[idx]*aunits.deg
+        ).transform_to(ICRS())
 
         RAJDnew[idx] = sc.ra.value
         DECJDnew[idx] = sc.dec.value
@@ -1303,35 +1304,41 @@ class QueryATNF(object):
         self.update(RAJnew, name='RAJ')
         self.update(DECJnew, name='DECJ')
 
-        ELONG_ERR = self.catalogue['ELONG_ERR']
-        ELAT_ERR = self.catalogue['ELAT_ERR']
-        RAJD_ERRnew = np.full(self.catalogue_len, np.nan)
-        DECJD_ERRnew = np.full(self.catalogue_len, np.nan)
-        RAJ_ERRnew = np.full(self.catalogue_len, np.nan)
-        DECJ_ERRnew = np.full(self.catalogue_len, np.nan)
+        reqpar = ['ELONG_ERR', 'ELAT_ERR']
+        if np.all([p in self.columns for p in reqpar]):
+            ELONG_ERR = self.catalogue['ELONG_ERR'].values.copy()
+            ELAT_ERR = self.catalogue['ELAT_ERR'].values.copy()
+            RAJD_ERRnew = np.full(self.catalogue_len, np.nan)
+            DECJD_ERRnew = np.full(self.catalogue_len, np.nan)
+            RAJ_ERRnew = np.full(self.catalogue_len, np.nan)
+            DECJ_ERRnew = np.full(self.catalogue_len, np.nan)
 
-        # get position angle towards Northern ecliptic pole and rotate
-        # ecliptical error ellipse to equatorial coordinates
-        # (Jean Meeus, Astronomal Algorithms, 2nd edition, p. 100)
-        ecl = 23.4392911 * aunits.deg
-        l, b = ELONG.values[idx] * aunits.deg, ELAT.values[idx] * aunits.deg
-        el, eb = ELONG_ERR.values[idx], ELAT_ERR.values[idx]
-        elcosb = el * np.cos(b)
-        q = np.arctan2(np.cos(l) * np.tan(ecl),
-                       np.sin(b) * np.sin(l) * np.tan(ecl) - np.cos(b))
-        cq, sq = np.cos(q), np.sin(q)
-        eracosdec, edec = np.abs(elcosb * cq - eb * sq), np.abs(elcosb * sq + eb * cq)
-        era = eracosdec / np.cos(sc.dec.radian)
+            idxerr = idx & np.isfinite(ELONG_ERR) & np.isfinite(ELAT_ERR)
 
-        RAJD_ERRnew[idx] = era
-        DECJD_ERRnew[idx] = edec
-        RAJ_ERRnew[idx] = 3600 * era / 15
-        DECJ_ERRnew[idx] = 3600 * edec
+            # get position angle towards Northern ecliptic pole and rotate
+            # ecliptical error ellipse to equatorial coordinates
+            # (Jean Meeus, Astronomal Algorithms, 2nd edition, p. 100)
+            ecl = 23.4392911 * aunits.deg
+            l, b = ELONG.values[idxerr] * aunits.deg, ELAT.values[idxerr] * aunits.deg
+            el, eb = ELONG_ERR.values[idxerr], ELAT_ERR.values[idxerr]
+            elcosb = el * np.cos(b)
+            q = np.arctan2(
+                np.cos(l) * np.tan(ecl),
+                np.sin(b) * np.sin(l) * np.tan(ecl) - np.cos(b)
+            )
+            cq, sq = np.cos(q), np.sin(q)
+            eracosdec, edec = np.abs(elcosb * cq - eb * sq), np.abs(elcosb * sq + eb * cq)
+            era = eracosdec / np.cos(np.deg2rad(DECJDnew[idxerr]))
 
-        self.update(RAJD_ERRnew, name='RAJD_ERR')
-        self.update(DECJD_ERRnew, name='DECJD_ERR')
-        self.update(RAJ_ERRnew, name='RAJ_ERR')
-        self.update(DECJ_ERRnew, name='DECJ_ERR')
+            RAJD_ERRnew[idxerr] = era
+            DECJD_ERRnew[idxerr] = edec
+            RAJ_ERRnew[idxerr] = 3600 * era / 15
+            DECJ_ERRnew[idxerr] = 3600 * edec
+
+            self.update(RAJD_ERRnew, name='RAJD_ERR')
+            self.update(DECJD_ERRnew, name='DECJD_ERR')
+            self.update(RAJ_ERRnew, name='RAJ_ERR')
+            self.update(DECJ_ERRnew, name='DECJ_ERR')
 
         # set references
         if 'ELONG_REF' in self.columns:
@@ -2880,7 +2887,7 @@ class QueryATNF(object):
             # use '!=' to find GC indexes
             nongcidxs = np.flatnonzero(
                 np.char.find(np.array(assocs.tolist(),
-                                      dtype=np.str), 'GC:') == -1)
+                                      dtype=str), 'GC:') == -1)
             periods = periods[nongcidxs]
             pdots = pdots[nongcidxs]
             if 'ASSOC' in table.columns:


### PR DESCRIPTION
This PR adds functionality to propagate the errors on ecliptical coordinates to equatorial coordinates. It uses a different algorithm to that in `psrcat` itself (see the `defineEquatorial` function in `defineParams.c`). It is not clear what the `psrcat` implementation does precisely.

This algorithm takes the errors in ecliptical coordinates and rotates them to the equatorial coordinate frame using the position angle between the North Ecliptical Pole and the North Equatorial Pole (taken from Jean Meeus' Astronomical Algorithms, 2nd edition, p. 100). Errors are corrected for `cos(ELAT)` and `cos(DECJ)` factors.

Comparison of the resulting errors on equatorial coordinates against the online PSRCAT results shows reasonable agreement. 