### PR TITLE
Use setuptools scm for package version

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -17,21 +17,31 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Get source code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-python@v2
         name: Install Python
         with:
           python-version: '3.7'
 
-      - name: Build sdist and wheel
-        run: |
-            python -m pip install build wheel setuptools setuptools_scm check-wheel-contents
-            python -m build . --sdist --wheel --outdir dist
-            check-wheel-contents dist/*.whl
+      - name: Install build requirements
+        run: python -m pip install build wheel setuptools setuptools_scm
+      
+      - name: Create distribution
+        run: python -m build . --sdist --wheel --outdir .
+
       - uses: actions/upload-artifact@v2
         with:
-          path: dist/psrqpy*
+          name: tarball
+          path: psrqpy-*.tar.*
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: wheel
+          path: psrqpy*.whl
 
   upload_pypi:
     needs: [build_dist]
@@ -42,7 +52,6 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: artifact
-          path: dist
 
       - uses: pypa/gh-action-pypi-publish@master
         with:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -26,8 +26,8 @@ jobs:
 
       - name: Build sdist and wheel
         run: |
-            python -m pip install wheel setuptools setuptools_scm check-wheel-contents
-            python setup.py sdist bdist_wheel --universal
+            python -m pip install build wheel setuptools setuptools_scm check-wheel-contents
+            python -m build . --sdist --wheel --outdir .
             check-wheel-contents dist/*.whl
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Build sdist and wheel
         run: |
             python -m pip install build wheel setuptools setuptools_scm check-wheel-contents
-            python -m build . --sdist --wheel --outdir .
+            python -m build . --sdist --wheel --outdir dist
             check-wheel-contents dist/*.whl
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Build sdist and wheel
         run: |
-            python -m pip install wheel check-wheel-contents
+            python -m pip install wheel setuptools setuptools_scm check-wheel-contents
             python setup.py sdist bdist_wheel --universal
             check-wheel-contents dist/*.whl
       - uses: actions/upload-artifact@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+psrqpy/_version.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,17 +17,8 @@ services:  # see https://docs.travis-ci.com/user/gui-and-headless-browsers/#usin
   - xvfb
 install:
   - pip install --upgrade pip
-  - pip install -r requirements.txt
-  # install additionally allowed packages
-  - pip install matplotlib ads
-  # install packages for documentation building
-  - pip install sphinx sphinx-rtd-theme recommonmark
-  # install packages for testing
-  - pip install --upgrade pytest>=3.6.3
-  - pip install pytest-cov pytest-socket
-  - pip install codecov
   # build psrqpy
-  - pip install -e .
+  - pip install -e .[docs,test]
 script:
   # run the test script
   - pytest --cov=psrqpy

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,0 @@
-include LICENSE
-include requirements.txt

--- a/README.md
+++ b/README.md
@@ -39,16 +39,14 @@ conda install -c conda-forge psrqpy
 
 The [requirements](requirements.txt) for installing the code are:
 
- * [`six`](https://six.readthedocs.io/)
  * [`requests`](http://docs.python-requests.org/en/master/)
  * [`beautifulsoup4`](https://www.crummy.com/software/BeautifulSoup/bs4/doc/)
  * [`numpy`](http://www.numpy.org/)
  * [`scipy`](https://www.scipy.org/)
  * [`astropy`](http://www.astropy.org/)
  * [`pandas`](https://pandas.pydata.org/)
-
-The [`ads`](https://ads.readthedocs.io/en/latest/) module is an optional requirement that is needed to get ADS URLs for references,
-and [`matplotlib`](https://matplotlib.org/) is required for making period-period derivative plots.
+ * [`ads`](https://ads.readthedocs.io/en/latest/)
+ * [`matplotlib`](https://matplotlib.org/)
 
 ## Examples
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -44,8 +44,8 @@ The requirements for installing the code are:
  * :mod:`astropy`
  * :mod:`pandas`
  * :mod:`scipy`
-
-The :mod:`ads` module and :mod:`matplotlib` are optional requirements to get the full functionality.
+ * :mod:`ads`
+ * :mod:`matplotlib`
 
 Examples
 ========

--- a/optional_requirements.txt
+++ b/optional_requirements.txt
@@ -1,2 +1,0 @@
-matplotlib
-ads

--- a/psrqpy/__init__.py
+++ b/psrqpy/__init__.py
@@ -7,7 +7,11 @@ from .search import QueryATNF
 from .pulsar import Pulsar, Pulsars
 from .utils import *
 
-__version__ = "1.1.3"
+try:
+    from ._version import version as __version__
+except ModuleNotFoundError:
+    __version__ = ""
+
 
 __citation__ = """@article{psrqpy,
   author = {{Pitkin}, M.},

--- a/psrqpy/config.py
+++ b/psrqpy/config.py
@@ -4,7 +4,6 @@ URLs used for queries.
 """
 
 import itertools
-from collections import OrderedDict
 
 
 #: The ATNF pulsar catalogue base URL.
@@ -27,7 +26,7 @@ MSP_URL = r"http://astro.phys.wvu.edu/GalacticMSPs/GalacticMSPs.txt"
 #  - 'ref': True if the parameter can have an associated reference in the ATNF catalogue
 #  - 'err': True if the parameter can have an associated error value
 #  - 'unit': a string giving the units for the parameter (to be used if generating an astropy table)
-PSR_GENERAL = OrderedDict()
+PSR_GENERAL = dict()
 PSR_GENERAL['NAME'] =     {'ref': True,  'err': False, 'units': None}  # Pulsar name. Default: B name
 PSR_GENERAL['JNAME'] =    {'ref': True,  'err': False, 'units': None}  # Pulsar name (J2000)
 PSR_GENERAL['BNAME'] =    {'ref': True,  'err': False, 'units': None}  # Pulsar Besselian name
@@ -100,7 +99,7 @@ PSR_GENERAL['EPHEM'] =    {'ref': True,  'err': False, 'units': None}
 PSR_GENERAL_PARS = list(PSR_GENERAL.keys())
 
 # timing solution and profile parameters
-PSR_TIMING = OrderedDict()
+PSR_TIMING = dict()
 PSR_TIMING['P0'] =      {'ref': True,  'err': True,  'units': 's'}  # Barycentric period
 # P1: Time derivative of barcycentric period
 PSR_TIMING['P1'] =      {'ref': True,  'err': True,  'units': None}
@@ -164,7 +163,7 @@ PSR_TIMING['SPINDX'] =  {'ref': True,  'err': True,  'units': None}   # Radio sp
 PSR_TIMING_PARS = list(PSR_TIMING.keys())
 
 # binary system parameters
-PSR_BINARY = OrderedDict()
+PSR_BINARY = dict()
 PSR_BINARY['BINARY'] =   {'ref': True,  'err': False, 'units': None}   # Binary model
 PSR_BINARY['T0'] =       {'ref': True,  'err': True,  'units': 'd'}   # Epoch of periastron (MJD)
 PSR_BINARY['PB'] =       {'ref': True,  'err': True,  'units': 'd'}   # Binary period of pulsar
@@ -247,7 +246,7 @@ PSR_BINARY['MINOMDOT'] = {'ref': False, 'err': False, 'units': 'deg/yr'}
 PSR_BINARY_PARS = list(PSR_BINARY.keys())
 
 # derived parameters
-PSR_DERIVED = OrderedDict()
+PSR_DERIVED = dict()
 PSR_DERIVED['R_LUM'] =   {'ref': False, 'err': False, 'units': 'mJy kpc^2'}   # Radio luminosity at 400 MHz
 PSR_DERIVED['R_LUM14'] = {'ref': False, 'err': False, 'units': 'mJy kpc^2'}   # Radio luminosity at 1400 MHz
 PSR_DERIVED['AGE'] =     {'ref': False, 'err': False, 'units': 'yr'}   # Spin down age
@@ -267,8 +266,8 @@ PSR_DERIVED['H0_SD'] =   {'ref': False, 'err': False, 'units': None}  # GW spin-
 PSR_DERIVED_PARS = list(PSR_DERIVED.keys())
 
 # a list of all allowed parameters for querying
-PSR_ALL = OrderedDict(itertools.chain(PSR_GENERAL.items(), PSR_TIMING.items(),
-                                      PSR_BINARY.items(), PSR_DERIVED.items()))
+PSR_ALL = dict(itertools.chain(PSR_GENERAL.items(), PSR_TIMING.items(),
+                               PSR_BINARY.items(), PSR_DERIVED.items()))
 """: A dictionary of allowed pulsars parameters (e.g., name, position,
 distance...)
 

--- a/psrqpy/pulsar.py
+++ b/psrqpy/pulsar.py
@@ -3,9 +3,6 @@ The classes defined here are hold information on an individual pulsar
 or an interable list of pulsars.
 """
 
-import warnings
-
-from six import string_types
 
 from .config import PSR_ALL_PARS, PSR_ALL
 
@@ -303,7 +300,7 @@ class Pulsars(object):
             psrname (str): a string with the name of a pulsar
         """
 
-        assert isinstance(psrname, string_types), "psrname is not a string"
+        assert isinstance(psrname, str), "psrname is not a string"
 
         if psrname in self._psrs:
             del self._psrs[psrname]
@@ -316,7 +313,7 @@ class Pulsars(object):
         Args:
             psrname (str): a string with the name of a pulsar
         """
-        assert isinstance(psrname, string_types), "psrname is not a string"
+        assert isinstance(psrname, str), "psrname is not a string"
 
         if psrname in self._psrs:
             self._num_pulsars -= 1

--- a/psrqpy/search.py
+++ b/psrqpy/search.py
@@ -5,11 +5,9 @@ information.
 """
 
 import warnings
-from collections import OrderedDict
 import re
 
 import pickle
-from six import string_types
 
 import numpy as np
 import astropy
@@ -159,8 +157,8 @@ class QueryATNF(object):
             self._coord1 = self._coord2 = ''
             self._radius = 0.
         else:
-            if (not isinstance(self._coord1, string_types)
-                    or not isinstance(self._coord2, string_types)):
+            if (not isinstance(self._coord1, str)
+                    or not isinstance(self._coord2, str)):
                 raise ValueError("Circular boundary centre coordinates must "
                                  "be strings")
             if not isinstance(self._radius, float) and not isinstance(self._radius, int):
@@ -271,7 +269,7 @@ class QueryATNF(object):
             self.get_references(useads=useadst)
 
         singleref = False
-        if isinstance(refs, string_types):
+        if isinstance(refs, str):
             singleref = True
             refs = [refs]
 
@@ -281,7 +279,7 @@ class QueryATNF(object):
 
         refstrs = []
         for ref in refs:
-            if isinstance(ref, string_types):
+            if isinstance(ref, str):
                 if ref in self._refs:
                     if useadst:
                         if ref in self._adsrefs:
@@ -429,7 +427,7 @@ class QueryATNF(object):
         Set the parameter to sort on.
         """
 
-        if not isinstance(value, string_types):
+        if not isinstance(value, str):
             raise ValueError("Sort parameter must be a string")
 
         self._sort_attr = value
@@ -596,7 +594,7 @@ class QueryATNF(object):
         if psrnames is None:
             self._psrs = None
         else:
-            if isinstance(psrnames, string_types):
+            if isinstance(psrnames, str):
                 self._psrs = [psrnames]
             elif isinstance(psrnames, list):
                 self._psrs = psrnames
@@ -712,7 +710,7 @@ class QueryATNF(object):
         if not self.empty:  # convert to Table if DataFrame is not empty
             if query_params is None:
                 query_params = self.columns
-            elif isinstance(query_params, string_types):
+            elif isinstance(query_params, str):
                 query_params = [query_params]
             elif not isinstance(query_params, list):
                 raise TypeError("query_params must be a string or list.")
@@ -732,9 +730,9 @@ class QueryATNF(object):
 
             # return given the condition
             expression = None
-            if usecondition is True and isinstance(self.condition, string_types):
+            if usecondition is True and isinstance(self.condition, str):
                 expression = self.condition
-            elif isinstance(usecondition, string_types):
+            elif isinstance(usecondition, str):
                 expression = usecondition
 
             # sort table
@@ -831,7 +829,7 @@ class QueryATNF(object):
                 to queried pulsars.
         """
 
-        if not isinstance(expression, string_types) and expression is not None:
+        if not isinstance(expression, str) and expression is not None:
             raise TypeError("Condition must be a string")
 
         self._condition = expression
@@ -911,12 +909,12 @@ class QueryATNF(object):
                 print('No query parameters have been specified')
 
             for p in params:
-                if not isinstance(p, string_types):
+                if not isinstance(p, str):
                     raise TypeError("Non-string value '{}' found in params "
                                     "list".format(p))
 
             self._query_params = [p.upper() for p in params]
-        elif isinstance(params, string_types):
+        elif isinstance(params, str):
             # make sure parameter is all upper case
             self._query_params = [params.upper()]
         elif params is not None:
@@ -2589,12 +2587,12 @@ class QueryATNF(object):
                     raise Exception("No pulsar types in list")
 
                 for p in psrtype:
-                    if not isinstance(p, string_types):
+                    if not isinstance(p, str):
                         raise Exception("Non-string value '{}' found in pulsar type list"
                                         .format(p))
                 self._query_psr_types = psrtype
             else:
-                if isinstance(psrtype, string_types):
+                if isinstance(psrtype, str):
                     self._query_psr_types = [psrtype]
                 else:
                     raise Exception("'psrtype' must be a list or string")
@@ -2617,12 +2615,12 @@ class QueryATNF(object):
                     raise Exception("No pulsar types in list")
 
                 for p in assoc:
-                    if not isinstance(p, string_types):
+                    if not isinstance(p, str):
                         raise Exception("Non-string value '{}' found in associations list"
                                         .format(p))
                 self._query_assocs = assoc
             else:
-                if isinstance(assoc, string_types):
+                if isinstance(assoc, str):
                     self._query_assocs = [assoc]
                 else:
                     raise Exception("'assoc' must be a list or string")
@@ -2645,12 +2643,12 @@ class QueryATNF(object):
                     raise Exception("No pulsar types in list")
 
                 for p in bincomp:
-                    if not isinstance(p, string_types):
+                    if not isinstance(p, str):
                         raise Exception("Non-string value '{}' found in binary "
                                         "companions list".format(p))
                 self._query_bincomps = bincomp
             else:
-                if isinstance(bincomp, string_types):
+                if isinstance(bincomp, str):
                     self._query_bincomps = [bincomp]
                 else:
                     raise Exception("'bincomp' must be a list or string")
@@ -2806,7 +2804,7 @@ class QueryATNF(object):
             print("No pulsars found, so no P-Pdot plot has been produced")
             return None
 
-        if isinstance(showtypes, string_types):
+        if isinstance(showtypes, str):
             nshowtypes = [showtypes]
         else:
             nshowtypes = showtypes
@@ -2974,7 +2972,7 @@ class QueryATNF(object):
         if showSNRs:
             nshowtypes.append('SNR')
 
-        handles = OrderedDict()
+        handles = dict()
 
         for stype in nshowtypes:
             if stype.upper() in PSR_TYPE + ['GC', 'SNR']:
@@ -3014,7 +3012,7 @@ class QueryATNF(object):
                           numpoints=1)
 
         # add characteristic age lines
-        tlines = OrderedDict()
+        tlines = dict()
         if showtau:
             if tau is None:
                 taus = [1e5, 1e6, 1e7, 1e8, 1e9]  # default characteristic ages
@@ -3035,7 +3033,7 @@ class QueryATNF(object):
                            .format(numv, taupow)] = tline
 
         # add magnetic field lines
-        Blines = OrderedDict()
+        Blines = dict()
         if showB:
             if Bfield is None:
                 Bs = [1e10, 1e11, 1e12, 1e13, 1e14]

--- a/psrqpy/utils.py
+++ b/psrqpy/utils.py
@@ -11,10 +11,6 @@ import requests
 import tarfile
 from bs4 import BeautifulSoup
 
-from six import string_types
-
-from collections import OrderedDict
-
 from astropy.table import Table
 from astropy.coordinates import SkyCoord, Angle
 import astropy.units as aunits
@@ -101,7 +97,7 @@ def get_catalogue(path_to_db=None, cache=True, update=False, pandas=False):
 
     # loop through lines in dbfile
     for line in dbfile.readlines():
-        if isinstance(line, string_types):
+        if isinstance(line, str):
             dataline = line.split()
         else:
             dataline = line.decode().split()  # Splits on whitespace
@@ -378,7 +374,7 @@ def get_glitch_catalogue(psr=None):
     rows = soup.table.find_all("tr")
 
     # set the table headings
-    tabledict = OrderedDict()
+    tabledict = dict()
     tabledict["NAME"] = []
     tabledict["JNAME"] = []
     tabledict["Glitch number"] = []
@@ -1336,7 +1332,7 @@ def condition(table, expression, exactMatch=False):
         else:
             return table[expression]
     else:
-        if not isinstance(expression, string_types):
+        if not isinstance(expression, str):
             raise TypeError("Expression must be a boolean array or a string")
         else:
             if len(expression) == 0:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[build-system]
+requires = [
+    "setuptools>=45",
+    "setuptools_scm>=6.2",
+    "wheel",
+]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+write_to = "psrqpy/_version.py"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,0 @@
-six
-requests
-beautifulsoup4
-numpy>=1.16
-scipy
-pandas>0.21
-astropy>=3.2
-packaging

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,54 @@
+[metadata]
+name = psrqpy
+author = Matthew Pitkin
+author_email = matthew.pitkin@ligo.org
+description = A Python module for querying the ATNF pulsar catalogue
+license = MIT
+license_files = LICENSE
+long_description = file: README.md
+long_description_content_type = text/markdown
+url = https://github.com/mattpitkin/psrqpy
+classifiers =
+    Intended Audience :: Science/Research
+    License :: OSI Approved :: MIT License
+    Natural Language :: English
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Topic :: Scientific/Engineering
+    Topic :: Scientific/Engineering :: Astronomy
+
+[options]
+python_requires = >=3.6, <4
+setup_requires =
+    setuptools >= 45
+    setuptools_scm >= 6.2
+    wheel
+install_requires =
+    ads
+    astropy>=3.2
+    beautifulsoup4
+    matplotlib
+    numpy>=1.16
+    packaging
+    pandas>0.21
+    requests
+    scipy
+include_package_data = True
+packages = find:
+
+[options.extras_require]
+test =
+    pytest>=3.6.3
+    pytest-cov
+    pytest-socket
+docs =
+    autodoc
+    recommonmark
+    sphinx >= 2.0
+    sphinx_rtd_theme
+
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -7,3 +7,4 @@ A Python module for accessing the ATNF pulsar catalogue
 from setuptools import setup
 
 setup(use_scm_version=True)
+

--- a/setup.py
+++ b/setup.py
@@ -4,42 +4,6 @@
 A Python module for accessing the ATNF pulsar catalogue
 """
 
-import os
-import re
-
 from setuptools import setup
 
-
-def readfile(filename):
-    with open(filename, encoding="utf-8") as fp:
-        filecontents = fp.read()
-    return filecontents
-
-
-VERSION_REGEX = re.compile('__version__ = "(.*?)"')
-CONTENTS = readfile(
-    os.path.join(os.path.dirname(os.path.abspath(__file__)), "psrqpy", "__init__.py")
-)
-
-VERSION = VERSION_REGEX.findall(CONTENTS)[0]
-
-setup(
-    name="psrqpy",
-    version=VERSION,
-    author="Matthew Pitkin",
-    author_email="matthew.pitkin@glasgow.ac.uk",
-    packages=["psrqpy"],
-    url="http://www.github.com/mattpitkin/psrqpy/",
-    license="MIT",
-    description="A Python module for querying the ATNF pulsar catalogue",
-    long_description=readfile(os.path.join(os.path.dirname(__file__), "README.md")),
-    long_description_content_type="text/markdown",
-    install_requires=readfile(
-        os.path.join(os.path.dirname(__file__), "requirements.txt")
-    ),
-    include_package_data=True,
-    classifiers=[
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-    ],
-)
+setup(use_scm_version=True)

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,3 +1,0 @@
-pytest>=3.6.3
-pytest-socket
-pytest-cov


### PR DESCRIPTION
This PR moves to using `setup.cfg` for all the build information. It also switches to using setuptools_scm for the version information. It also removes any residual Python 2 requirements.

Closes #84.