### PR TITLE
Resolve "Version downloads"

### DIFF
--- a/psrqpy/config.py
+++ b/psrqpy/config.py
@@ -12,6 +12,9 @@ ATNF_BASE_URL = r"http://www.atnf.csiro.au/people/pulsar/psrcat/"
 #: The name of the tarball containing the entire catalogue database.
 ATNF_TARBALL = ATNF_BASE_URL + r"downloads/psrcat_pkg.tar.gz"
 
+#: The name of the tarball containing the entire catalogue database (allowing version string to be added).
+ATNF_VERSION_TARBALL = ATNF_BASE_URL + r"downloads/psrcat_pkg.v{}.tar.gz"
+
 #: The Jodrell Bank glitch catalogue table URL.
 GLITCH_URL = r"http://www.jb.man.ac.uk/pulsar/glitches/gTable.html"
 

--- a/psrqpy/config.py
+++ b/psrqpy/config.py
@@ -12,7 +12,8 @@ ATNF_BASE_URL = r"http://www.atnf.csiro.au/people/pulsar/psrcat/"
 #: The name of the tarball containing the entire catalogue database.
 ATNF_TARBALL = ATNF_BASE_URL + r"downloads/psrcat_pkg.tar.gz"
 
-#: The name of the tarball containing the entire catalogue database (allowing version string to be added).
+# The name of the tarball containing the entire catalogue database (allowing version string to
+# be added).
 ATNF_VERSION_TARBALL = ATNF_BASE_URL + r"downloads/psrcat_pkg.v{}.tar.gz"
 
 #: The Jodrell Bank glitch catalogue table URL.

--- a/psrqpy/search.py
+++ b/psrqpy/search.py
@@ -109,6 +109,9 @@ class QueryATNF(object):
         checkupdate (bool): If True then check whether a cached catalogue file
             has an update available, and re-download if there is an update.
             Defaults to False.
+        version (str): the version string (without the leading "v") of the ATNF
+            catalogue version to download. This defaults to "latest" to get the
+            most up-to-date version.
         frompandas (:class:`pandas.DataFrame`): create a new
             :class:`psrqpy.QueryATNF` object from an existing
             :class:`pandas.DataFrame`.
@@ -123,7 +126,8 @@ class QueryATNF(object):
                  include_refs=False, adsref=False, loadfromfile=None,
                  loadquery=None, loadfromdb=None, cache=True,
                  checkupdate=False, circular_boundary=None, coord1=None,
-                 coord2=None, radius=0., frompandas=None, fromtable=None):
+                 coord2=None, radius=0., frompandas=None, fromtable=None,
+                 version="latest"):
         if loadfromfile is not None and loadquery is None:
             loadquery = loadfromfile
         if loadquery:
@@ -210,7 +214,7 @@ class QueryATNF(object):
         # download and cache (if requested) the database file
         try:
             _ = self.get_catalogue(path_to_db=loadfromdb, cache=cache,
-                                   update=checkupdate)
+                                   update=checkupdate, version=version)
         except IOError:
             raise IOError("Could not get catalogue database file")
 
@@ -306,7 +310,7 @@ class QueryATNF(object):
         return refstrs
 
     def get_catalogue(self, path_to_db=None, cache=True, update=False,
-                      overwrite=True):
+                      overwrite=True, version="latest"):
         """
         Call the :func:`psrqpy.utils.get_catalogue` function to download the
         ATNF Pulsar Catalogue, or load a given catalogue path.
@@ -324,6 +328,9 @@ class QueryATNF(object):
                 catalogue currently contained within the :class:`~psrqpy.QueryATNF`
                 class. If False then a new :class:`~psrqpy.QueryATNF` copy of the
                 catalogue will be returned.
+            version (str): the version string (without the leading "v") of the ATNF
+                catalogue version to download. This defaults to "latest" to get the
+                most up-to-date version.
 
         Returns:
             :class:`psrqpy.QueryATNF`: a table containing the catalogue.
@@ -332,7 +339,8 @@ class QueryATNF(object):
 
         try:
             dbtable = get_catalogue(path_to_db=path_to_db, cache=cache,
-                                    update=update, pandas=True)
+                                    update=update, pandas=True,
+                                    version=version)
         except Exception as e:
             raise RuntimeError("Problem getting catalogue: {}".format(str(e)))
 

--- a/psrqpy/utils.py
+++ b/psrqpy/utils.py
@@ -21,6 +21,7 @@ from .config import (
     ATNF_BASE_URL,
     ADS_URL,
     ATNF_TARBALL,
+    ATNF_VERSION_TARBALL,
     MSP_URL,
     PSR_ALL,
     PSR_ALL_PARS,
@@ -29,7 +30,7 @@ from .config import (
 )
 
 
-def get_catalogue(path_to_db=None, cache=True, update=False, pandas=False):
+def get_catalogue(path_to_db=None, cache=True, update=False, pandas=False, version="latest"):
     """
     This function will attempt to download and cache the entire ATNF Pulsar
     Catalogue database `tarball
@@ -54,6 +55,9 @@ def get_catalogue(path_to_db=None, cache=True, update=False, pandas=False):
         pandas (bool): if True the catalogue will be returned as a
             :class:`pandas.DataFrame` rather than the default of an
             :class:`~astropy.table.Table`.
+        version (str): the version string (without the leading "v") of the ATNF
+            catalogue version to download. This defaults to "latest" to get the
+            most up-to-date version.
 
     Returns:
         :class:`~astropy.table.Table` or :class:`~pandas.DataFrame`: a table
@@ -67,11 +71,18 @@ def get_catalogue(path_to_db=None, cache=True, update=False, pandas=False):
             if check_update():
                 clear_download_cache(ATNF_TARBALL)
 
+        if version == "latest":
+            atnftarball = ATNF_TARBALL
+        else:
+            atnftarball = ATNF_VERSION_TARBALL.format(version)
+
         # get the tarball
         try:
-            dbtarfile = download_file(ATNF_TARBALL, cache=cache)
+            dbtarfile = download_file(atnftarball, cache=cache)
         except IOError:
-            raise IOError("Problem accessing ATNF catalogue tarball")
+            raise IOError(
+                "Problem accessing ATNF catalogue tarball: {}".format(atnftarball)
+            )
 
         try:
             # open tarball


### PR DESCRIPTION
The resolves #94 by allowing the user to specify the version of the ATNF catalogue to download, e.g.:

```python
from psrqpy import QueryATNF
q = QueryATNF(version="1.64")

print(q.get_version)
1.64
```