### PR TITLE
If POSEPOCH is not present, copy the value from PEPOCH

### DIFF
--- a/psrqpy/utils.py
+++ b/psrqpy/utils.py
@@ -256,7 +256,7 @@ def get_catalogue(path_to_db=None, cache=True, update=False, pandas=False, versi
 
         # always include a value for POSEPOCH if PEPOCH is present
         # this matches the behaviour of the psrcat v1.66 CLI (definePosEpoch.c:202-213)
-        if not "POSEPOCH" in psr.keys() and "PEPOCH" in psr.keys():
+        if "POSEPOCH" not in psr.keys() and "PEPOCH" in psr.keys():
             psrlist[i]["POSEPOCH"] = psrlist[i]["PEPOCH"]
             if "PEPOCH_REF" in psr.keys():
                 psrlist[i]["POSEPOCH_REF"] = psrlist[i]["PEPOCH_REF"]

--- a/psrqpy/utils.py
+++ b/psrqpy/utils.py
@@ -254,6 +254,13 @@ def get_catalogue(path_to_db=None, cache=True, update=False, pandas=False, versi
 
                 psrlist[i]["DECJD_ERR"] = (psr["DECJ_ERR"] * decunit).to("deg").value
 
+        # always include a value for POSEPOCH if PEPOCH is present
+        # this matches the behaviour of the psrcat v1.66 CLI (definePosEpoch.c:202-213)
+        if not "POSEPOCH" in psr.keys() and "PEPOCH" in psr.keys():
+            psrlist[i]["POSEPOCH"] = psrlist[i]["PEPOCH"]
+            if "PEPOCH_REF" in psr.keys():
+                psrlist[i]["POSEPOCH_REF"] = psrlist[i]["PEPOCH_REF"]
+
     # convert to a pandas DataFrame - this will fill in empty spaces
     dftable = DataFrame(psrlist)
 


### PR DESCRIPTION
Hi Matt,

I came across an issue with the DATE parameter (PR to follow shortly), and while looking at fixing it I found that psrqpy seemed to have a significantly reduced number of POSEPOCH values as compared to a query to psrcat. Digging into the psrcat source, it seems that if a value for POSEPOCH is not set for a source, psrcat will copy over the value from the PEPOCH parameter to fill in the gap.

I've run the pytest suite on the PR and this passes all tests. Any warnings also appeared in the current HEAD version. Though there will be a slight reduction in code coverage as I haven't written new tests.

> ❯ git symbolic-ref --short HEAD
> posepoch_from_pepoch
> ❯ pytest
> ============================= test session starts ==============================
> platform linux -- Python 3.9.5, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
> rootdir: /home/suddenly/git/psrqpy, configfile: pytest.ini
> plugins: socket-0.5.1, cov-3.0.0, anyio-3.3.0
> collected 36 items                                                             
> 
> psrqpy/tests/query_test.py ....................................          [100%]
> 
> =============================== warnings summary ===============================
> psrqpy/tests/query_test.py::test_ppdot_diagram
> psrqpy/tests/query_test.py::test_ppdot_diagram
> psrqpy/tests/query_test.py::test_ppdot_diagram
> psrqpy/tests/query_test.py::test_ppdot_diagram
> psrqpy/tests/query_test.py::test_ppdot_diagram
> psrqpy/tests/query_test.py::test_ppdot_diagram
>   DeprecationWarning: `np.str` is a deprecated alias for the builtin `str`. To silence this warning, use `str` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.str_` here.
>   Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
> 
> -- Docs: https://docs.pytest.org/en/stable/warnings.html
> ======================= 36 passed, 6 warnings in 24.46s ========================
> 


Here's a copy of the C code in psrcat v1.66, definePosEpoch.c:definePosEpoch() as a quick reference.

```
/* ************** */
/* Position Epoch */
/* ************** */
void definePosEpoch(pulsar *psr,int ip,int type)
{
  int ip1,len,date,i;
  char ref[4];
  double val1;
  /* If posepoch is not set, then set it to the period epoch */
  if (type==1)
    {
      ip1 = getParam("PEPOCH",NULL);
      if (psr->param[ip1].set1==1)
        {
          val1 = psr->param[ip1].shortVal;
          psr->param[ip].set1 = 1; psr->param[ip].shortVal = val1; sprintf(psr->param[ip].val,"%8.2f",val1);  
          psr->param[ip].derived = 1;
          if (pcat_maxSize[ip] < strlen(psr->param[ip].val)) pcat_maxSize[ip]=strlen(psr->param[ip].val);              
        }
    }
...
}
```
I've tried to match your code style, but let me know if there's anything off in that regard or anything else you'd like me to change.

Cheers,
David