### PR TITLE
Derive the value for the "DATE" parameter.

### DIFF
--- a/psrqpy/search.py
+++ b/psrqpy/search.py
@@ -3001,11 +3001,11 @@ class QueryATNF(object):
                 elif thistype in ['GC', 'SNR']:
                     typeidx = np.flatnonzero(
                         np.char.find(np.array(assocs.tolist(),
-                                              dtype=np.str), thistype) != -1)
+                                              dtype=str), thistype) != -1)
                 else:
                     typeidx = np.flatnonzero(
                         np.char.find(np.array(types.tolist(),
-                                              dtype=np.str), thistype) != -1)
+                                              dtype=str), thistype) != -1)
 
                 if len(typeidx) == 0:
                     continue

--- a/psrqpy/tests/query_test.py
+++ b/psrqpy/tests/query_test.py
@@ -8,7 +8,6 @@ from psrqpy import QueryATNF
 import numpy as np
 from pandas import Series
 import pytest_socket
-from six import string_types
 from astropy.table.column import MaskedColumn
 
 
@@ -119,7 +118,7 @@ def test_get_pulsars(query):
 
     crabeph = query.get_ephemeris('J0534+2200')
 
-    assert isinstance(crabeph, string_types)
+    assert isinstance(crabeph, str)
 
     for line in crabeph.split('\n'):
         if line.split()[0].strip() == 'F0':
@@ -344,7 +343,7 @@ def test_get_references(query):
     # test parsing a reference
     ref = query.parse_ref('ksm+06')
 
-    assert isinstance(ref, string_types)
+    assert isinstance(ref, str)
     assert "Kramer" in ref and "Science" in ref and "314" in ref and "2006" in ref
 
     # test parsing two references

--- a/psrqpy/utils.py
+++ b/psrqpy/utils.py
@@ -261,6 +261,16 @@ def get_catalogue(path_to_db=None, cache=True, update=False, pandas=False, versi
             if "PEPOCH_REF" in psr.keys():
                 psrlist[i]["POSEPOCH_REF"] = psrlist[i]["PEPOCH_REF"]
 
+        # derive the 'DATE' parameter from the 'POSEPOCH' reference
+        # implementation based upon the psrcat v1.66 CLI (definePosEpoch.c:214-242)
+        if "POSEPOCH_REF" in psr.keys():
+            refyear = int(re.search(r"(\d{2})(?!.*\d)", psrlist[i]["POSEPOCH_REF"]).group(0))
+            if refyear > 65:
+                refyear += 1900
+            else:
+                refyear += 2000
+            psrlist[i]['DATE'] = refyear
+
     # convert to a pandas DataFrame - this will fill in empty spaces
     dftable = DataFrame(psrlist)
 

--- a/psrqpy/utils.py
+++ b/psrqpy/utils.py
@@ -264,12 +264,15 @@ def get_catalogue(path_to_db=None, cache=True, update=False, pandas=False, versi
         # derive the 'DATE' parameter from the 'POSEPOCH' reference
         # implementation based upon the psrcat v1.66 CLI (definePosEpoch.c:214-242)
         if "POSEPOCH_REF" in psr.keys():
-            refyear = int(re.search(r"(\d{2})(?!.*\d)", psrlist[i]["POSEPOCH_REF"]).group(0))
-            if refyear > 65:
-                refyear += 1900
-            else:
-                refyear += 2000
-            psrlist[i]['DATE'] = refyear
+            try:
+                refyear = int(re.search(r"(\d{2})(?!.*\d)", psrlist[i]["POSEPOCH_REF"]).group(0))
+                if refyear > 65:
+                    refyear += 1900
+                else:
+                    refyear += 2000
+                psrlist[i]['DATE'] = refyear
+            except (AttributeError, TypeError):
+                pass
 
     # convert to a pandas DataFrame - this will fill in empty spaces
     dftable = DataFrame(psrlist)

--- a/psrqpy/utils.py
+++ b/psrqpy/utils.py
@@ -254,6 +254,13 @@ def get_catalogue(path_to_db=None, cache=True, update=False, pandas=False, versi
 
                 psrlist[i]["DECJD_ERR"] = (psr["DECJ_ERR"] * decunit).to("deg").value
 
+        # always include a value for POSEPOCH if PEPOCH is present
+        # this matches the behaviour of the psrcat v1.66 CLI (definePosEpoch.c:202-213)
+        if "POSEPOCH" not in psr.keys() and "PEPOCH" in psr.keys():
+            psrlist[i]["POSEPOCH"] = psrlist[i]["PEPOCH"]
+            if "PEPOCH_REF" in psr.keys():
+                psrlist[i]["POSEPOCH_REF"] = psrlist[i]["PEPOCH_REF"]
+
     # convert to a pandas DataFrame - this will fill in empty spaces
     dftable = DataFrame(psrlist)
 


### PR DESCRIPTION
Hi Matt,

In the current v1.1.6 on pip if "DATE" is requested all attempts to interact with the returned catalogue raise a key error as the DATE value is never derived from the catalogue. Here's a example of the issue I'm seeing:

```
Python 3.9.5 (default, May 11 2021, 08:20:37) 
Type 'copyright', 'credits' or 'license' for more information
IPython 7.25.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import psrqpy

In [2]: cat = psrqpy.QueryATNF(params = ['JNAME', 'SURVEY', 'DATE'])
cat.dataframe.
In [3]: cat.dataframe.head()
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)

....

KeyError: "['DATE'] not in index"

In [4]: cat
Out[4]: ---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)

....

KeyError: "['DATE'] not in index"

```

As of psrcat v1.66, the DATE parameter seems to be derived at runtime in definePosEpoch.c:definePosEpoch():

```
/* ************** */
/* Position Epoch */
/* ************** */
void definePosEpoch(pulsar *psr,int ip,int type)
{
...
  else if (type==2) /* Discovery date */
    {
      if (strcmp(psr->param[0].ref,NO_REF)!=0) /* Obtain from the reference to the PSRJ name */
        {
          len = strlen(psr->param[0].ref);
          /* go from the end and find the first numeral */
          /* In case the reference is something like abc45a */
          for (i=len;i--;)
            {
              if (isdigit(psr->param[0].ref[i]))
                {
                  len = i;
                  break;
                }
            }
          ref[0] = psr->param[0].ref[len-1];
          ref[1] = psr->param[0].ref[len];
          ref[2] = '\0';
          /* Have only the last two digits of the date */
          sscanf(ref,"%d",&date);
          if (date > 65)
            date = 1900+date;
          else
            date = 2000+date;
          psr->param[ip].set1 = 1; psr->param[ip].shortVal = date; sprintf(psr->param[ip].val,"%-5d",date);  
          psr->param[ip].derived = 1;
          if (pcat_maxSize[ip] < strlen(psr->param[ip].val)) pcat_maxSize[ip]=strlen(psr->param[ip].val);             
        }      
    }
}
```

I'm not too big of a fan of that method to derive the date myself, but that's how it's defined in psrcat so I've re-implemented it in util.py here.

Similar to PR #96, running the test suite only raised new warnings, and given I haven't written any tests there will be a slight reduction in code coverage from this PR. Let me know if you want any changes.

Cheers,
David