### PR TITLE
Cache QueryATNF look-ups in pulsar.py

### DIFF
--- a/psrqpy/pulsar.py
+++ b/psrqpy/pulsar.py
@@ -6,6 +6,9 @@ or an interable list of pulsars.
 
 from .config import PSR_ALL_PARS, PSR_ALL
 
+# Create a local cache variable fo a QueryATNF object
+import copy
+_cached_query = None
 
 class Pulsar(object):
     """
@@ -100,12 +103,14 @@ class Pulsar(object):
             else:
                 # generate a query for the key and add it
                 if self._query is None:
-                    try:
-                        from .search import QueryATNF
-
-                        self._query = QueryATNF()
-                    except IOError:
-                        raise Exception("Problem querying ATNF catalogue")
+                    global _cached_query
+                    if _cached_query is None:
+                        try:
+                            from .search import QueryATNF
+                            _cached_query = QueryATNF()
+                        except IOError:
+                            raise Exception("Problem querying ATNF catalogue")
+                    self._query = copy.deepcopy(_cached_query)
 
             psrrow = self._query.get_pulsar(pulsarname)
 


### PR DESCRIPTION
Hi Matt,

I ran into a performance bottleneck a while back while calling the psrqpy.pulsar.Pulsar object to create new sources. At the time I hadn't paid attention to the optional query kwarg, but started using it after I noticed it. I got sent a block of code from someone recently who had the same performance issues and wondered why, so I thought it might be worthwhile to offer a patch to cache the creation of the QueryATNF object when looking up individual pulsars.

As is, if the query kwarg is not set, calling a lookup on a variable for a psrqpy.pulsar.Pulsar will always generate a new QueryATNF lookup. This, needless to say, can be a bit slow. This PR adds a new "_cached_query" global variable to pulsar.py which is initially not set until a psrqpy.pulsar.Pulsar object has a lookup performed, but is then cached and cloned for further calls. To prevent issues with the query potentially having different states after performing look-ups on different sources, I use the builtin "copy" library to take a fresh copy of the cached QueryATNF variable for each new psrqpy.pulsar.Pulsar object.

Here is a sample block of code I was running in a few cells in ipython: taking the first 5 pulsar entries in psrcat, extracting the names, then looking up each of their DMs.

```python
import psrqpy.pulsar as psr

samplePSRsStr = """1     J0002+6216    cwp+17 
2     J0006+1834    cnt96 
3     J0007+7303    aaa+09c 
4     J0011+08      dsm+16 
5     J0014+4746    dth78 """.split('\n')
samplePSRs = [entry.split()[1] for entry in samplePSRsStr]

%%timeit
pulsarDMs = []
for source in samplePSRs:
    pulsarDMs.append(psr.Pulsar(source)['DM'])
```

On the current head, the %%timeit  cell takes quite a while to run for 5 sources, regardless of how many times the cell is run (these are back-to-back runs in the same session)

> 38.6 s ± 1.51 s per loop (mean ± std. dev. of 7 runs, 1 loop each)
> 38.3 s ± 412 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

But with the proposed change, after the first QueryATNF object is created (~7-10 seconds on my machine), things run a lot faster:

> 1.58 s ± 94 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
> 1.61 s ± 40.3 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
> 1.61 s ± 38.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

All tests still pass after these changes:

> ❯ pytest
> =================================================================== test session starts ====================================================================
> platform linux -- Python 3.10.4, pytest-7.1.2, pluggy-1.0.0
> rootdir: /home/suddenly/git/psrqpy, configfile: pytest.ini
> plugins: socket-0.5.1, anyio-3.5.0
> collected 36 items                                                                                                                                         
> 
> psrqpy/tests/query_test.py ....................................                                                                                      [100%]
> 
> =================================================================== 36 passed in 24.79s ====================================================================


Let me know what you think about the changes, I know a lot of people aren't a fan of global variable caches, but I feel like this could improve the out-of-the-box experience for people trying to jump into using the library without paying too much attention to the documentation.

Cheers,
David