### PR TITLE
Cache QueryATNF object

### DIFF
--- a/psrqpy/pulsar.py
+++ b/psrqpy/pulsar.py
@@ -6,6 +6,9 @@ or an interable list of pulsars.
 
 from .config import PSR_ALL_PARS, PSR_ALL
 
+# Create a local cache variable fo a QueryATNF object
+import copy
+_cached_query = None
 
 class Pulsar(object):
     """
@@ -100,12 +103,14 @@ class Pulsar(object):
             else:
                 # generate a query for the key and add it
                 if self._query is None:
-                    try:
-                        from .search import QueryATNF
-
-                        self._query = QueryATNF()
-                    except IOError:
-                        raise Exception("Problem querying ATNF catalogue")
+                    global _cached_query
+                    if _cached_query is None:
+                        try:
+                            from .search import QueryATNF
+                            _cached_query = QueryATNF()
+                        except IOError:
+                            raise Exception("Problem querying ATNF catalogue")
+                    self._query = copy.deepcopy(_cached_query)
 
             psrrow = self._query.get_pulsar(pulsarname)
 

--- a/psrqpy/pulsar.py
+++ b/psrqpy/pulsar.py
@@ -6,9 +6,6 @@ or an interable list of pulsars.
 
 from .config import PSR_ALL_PARS, PSR_ALL
 
-# Create a local cache variable fo a QueryATNF object
-import copy
-_cached_query = None
 
 class Pulsar(object):
     """
@@ -103,14 +100,12 @@ class Pulsar(object):
             else:
                 # generate a query for the key and add it
                 if self._query is None:
-                    global _cached_query
-                    if _cached_query is None:
-                        try:
-                            from .search import QueryATNF
-                            _cached_query = QueryATNF()
-                        except IOError:
-                            raise Exception("Problem querying ATNF catalogue")
-                    self._query = copy.deepcopy(_cached_query)
+                    try:
+                        from .search import QueryATNF
+
+                        self._query = QueryATNF()
+                    except IOError:
+                        raise Exception("Problem querying ATNF catalogue")
 
             psrrow = self._query.get_pulsar(pulsarname)
 

--- a/psrqpy/tests/query_test.py
+++ b/psrqpy/tests/query_test.py
@@ -3,7 +3,6 @@ Test script.
 """
 
 import pytest
-import os
 from psrqpy import QueryATNF
 import numpy as np
 from pandas import Series

--- a/psrqpy/utils.py
+++ b/psrqpy/utils.py
@@ -69,7 +69,7 @@ def get_catalogue(path_to_db=None, cache=True, update=False, pandas=False, versi
         # remove any cached file if requested
         if update:
             if check_update():
-                clear_download_cache(ATNF_TARBALL)
+                clear_download_cache(ATNF_TARBALL, pkgname="psrqpy")
 
         if version == "latest":
             atnftarball = ATNF_TARBALL
@@ -78,7 +78,7 @@ def get_catalogue(path_to_db=None, cache=True, update=False, pandas=False, versi
 
         # get the tarball
         try:
-            dbtarfile = download_file(atnftarball, cache=cache)
+            dbtarfile = download_file(atnftarball, cache=cache, pkgname="psrqpy")
         except IOError:
             raise IOError(
                 "Problem accessing ATNF catalogue tarball: {}".format(atnftarball)


### PR DESCRIPTION
Currently, if caching (the default) using the `QueryATNF` object, it actually only caches the downloaded ATNF catalogue tarball.  When generating new queries using `QueryATNF`, even using this cached file can take a few to tens of second to load (due partly to having to recalculate all the derived parameters. This PR instead caches and re-loaded the `QueryATNF` object itself, which is considerably quicker.

The default location of the cache objects has also been changed to be in a `~/.psrqpy` directory.

This supersedes #102.