### PR TITLE
Prevent caching of local database files

### DIFF
--- a/psrqpy/search.py
+++ b/psrqpy/search.py
@@ -385,7 +385,7 @@ class QueryATNF(object):
         self.set_derived()
         self.parse_types()
 
-        if cache:
+        if cache and path_to_db is None:
             # save Query to cache file
             if not os.path.exists(cachedir):
                 try:

--- a/psrqpy/tests/query_test.py
+++ b/psrqpy/tests/query_test.py
@@ -282,7 +282,10 @@ def test_num_pulsars(query):
     query.psrs = 'J9999+9999'  # bad pulsar
 
     # length should be zero
-    assert len(query) == 0
+    with pytest.warns(UserWarning):
+        lq = len(query)
+
+    assert lq == 0
 
     query.psrs = 'J0534+2200'  # Crab pulsar
 


### PR DESCRIPTION
Fix a bug introduced in #103 that meant that if you loaded a local database file (and left the default setting of `cache=True`) that file would get cached and overwrite the full catalogue. This caused issues with testing due to the tests loading a local test database.

A check for a `UserWarning` has also been added in the tests.