### PR TITLE
Add S350 flux value

### DIFF
--- a/psrqpy/config.py
+++ b/psrqpy/config.py
@@ -150,6 +150,7 @@ PSR_TIMING['S100'] =    {'ref': True,  'err': True,  'units': 'mJy'}  # Mean flu
 PSR_TIMING['S150'] =    {'ref': True,  'err': True,  'units': 'mJy'}  # Mean flux at 150 MHz
 PSR_TIMING['S200'] =    {'ref': True,  'err': True,  'units': 'mJy'}  # Mean flux at 200 MHz
 PSR_TIMING['S300'] =    {'ref': True,  'err': True,  'units': 'mJy'}  # Mean flux at 300 MHz
+PSR_TIMING['S350'] =    {'ref': True,  'err': True,  'units': 'mJy'}  # Mean flux at 350 MHz
 PSR_TIMING['S600'] =    {'ref': True,  'err': True,  'units': 'mJy'}  # Mean flux at 600 MHz
 PSR_TIMING['S700'] =    {'ref': True,  'err': True,  'units': 'mJy'}  # Mean flux at 700 MHz
 PSR_TIMING['S800'] =    {'ref': True,  'err': True,  'units': 'mJy'}  # Mean flux at 800 MHz

--- a/psrqpy/pulsar.py
+++ b/psrqpy/pulsar.py
@@ -138,8 +138,7 @@ class Pulsar(object):
     def __getattr__(self, key):
         """
         If the class has a attribute given by the key then return it, otherwise
-        generate a query for that key to set it (use the already defined
-        __getitem__)
+        raise an error.
         """
 
         ukey = key.upper()


### PR DESCRIPTION
As of v1.68 (or maybe from 1.66/67 onwards), so pulsar have an S350 flux value. This can now be extracted from a psrqpy query. Note that there are no pulsars for which the S30, S10G, S20G and S50G are added yet, so these are not listed as parameters available within psrqpy yet.