### PR TITLE
Run the build workflow nightly at midnight

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  schedule:
+    - cron: "0 0 * * *"
 
 jobs:
   build:


### PR DESCRIPTION
This PR patches the CI config for the `build.yml` workflow to run the workflow nightly. This should help catch issues like #116 sooner.