### PR TITLE
Fix parsing of the glitch catalogue table

### DIFF
--- a/psrqpy/utils.py
+++ b/psrqpy/utils.py
@@ -504,7 +504,7 @@ def get_glitch_catalogue(psr=None):
             ):
                 try:
                     val = float(tds[4 + j].contents[0].string)
-                except ValueError:
+                except (ValueError, TypeError):
                     val = np.nan
 
                 tabledict[pname].append(val)


### PR DESCRIPTION
The parsing of the [glitch catalogue table](https://www.jb.man.ac.uk/pulsar/glitches/gTable.html) is currently [failing](https://github.com/mattpitkin/psrqpy/actions/runs/4258176268/jobs/7409127175). I think this is due to the inclusion of a glitch for PSR J1904-1629, which currently has several empty columns.  This PR (hopefully) fixes this by allowing `TypeError` as potential exception when parsing the values from a row in the table.