### PR TITLE
Match psrcat behavior for the "NAME" parameter

### DIFF
--- a/psrqpy/utils.py
+++ b/psrqpy/utils.py
@@ -199,20 +199,23 @@ def get_catalogue(
         # add 'JNAME', 'BNAME' and 'NAME'
         if "PSRJ" in psr.keys():
             psrlist[i]["JNAME"] = psr["PSRJ"]
-            psrlist[i]["NAME"] = psr["PSRJ"]
             if "PSRJ_REF" in psr.keys():
                 psrlist[i]["JNAME_REF"] = psr["PSRJ_REF"]
-                psrlist[i]["NAME_REF"] = psr["PSRJ_REF"]
 
         if "PSRB" in psr.keys():
             psrlist[i]["BNAME"] = psr["PSRB"]
             if "PSRB_REF" in psr.keys():
                 psrlist[i]["BNAME_REF"] = psr["PSRB_REF"]
 
-            if "NAME" not in psrlist[i].keys():
-                psrlist[i]["NAME"] = psr["PSRB"]
-                if "PSRB_REF" in psr.keys():
-                    psrlist[i]["NAME_REF"] = psr["PSRB_REF"]
+        if "PSRB" in psr.keys() and "PSRJ" in psr.keys():
+            psrlist[i]["NAME"] = psr["PSRB"]
+            if "PSRB_REF" in psr.keys():
+                psrlist[i]["NAME_REF"] = psr["PSRB_REF"]
+
+        else:
+            psrlist[i]["NAME"] = psr["PSRJ"]
+            if "PSRJ_REF" in psr.keys():
+                psrlist[i]["NAME_REF"] = psr["PSRJ_REF"]
 
         if "RAJ" in psr.keys() and "DECJ" in psr.keys():
             # check if the string can be converted to a float (there are a few


### PR DESCRIPTION
When querying the database for the name parameters, the package currently behaves this way:
```
>>> import psrqpy
>>> q = psrqpy.QueryATNF(psrs = ['J0034-0721','J1906+1854'], params = ['Name','JName','BName'])
>>> print(q)
JNAME       NAME     BNAME
---------- ---------- --------
J0034-0721 J0034-0721 B0031-07
J1906+1854 J1906+1854       --
```

With these modifications, the same code would return the following table, which matches the behavior of psrcat for the "NAME" parameter (PSRB if it exists, otherwise PSRJ) :
```  
JNAME       NAME     BNAME  
---------- ---------- --------
J0034-0721   B0031-07 B0031-07
J1906+1854 J1906+1854       --
```
