### PR TITLE
Ignore database lines with no value

### DIFF
--- a/psrqpy/utils.py
+++ b/psrqpy/utils.py
@@ -140,6 +140,10 @@ def get_catalogue(
             psrlist.append({})  # New object!
             continue
 
+        if len(dataline) == 1:
+            # line contains a field with no associated value
+            continue
+
         try:
             psrlist[-1][dataline[0]] = float(dataline[1])
         except ValueError:


### PR DESCRIPTION
Currently, when reading from the ATNF catalogue database files, the code assumes that all fields have an associated value, i.e., each lines consists of at least:

```txt
FIELD_NAME VALUE
```

There might be errors in the file where no value is specified. These should be harmless, but at the moment they break the code that parses the file. This PR fixes this by skipping lines that contain only a single item.