### PR TITLE
Update value, error formatting logic

### DIFF
--- a/psrqpy/search.py
+++ b/psrqpy/search.py
@@ -2516,23 +2516,20 @@ class QueryATNF(object):
             if isinstance(varval, float):
                 if varval.is_integer():
                     precstr = '{0:.0f}'  # print out an integer
-                else:
-                    precstr = '{{0:.{}f}}'.format(precision)  # print out float
-
-                if abs(varval) < 1e-6 or abs(varval) > 1e6:
+                elif abs(varval) < 1e-6 or abs(varval) > 1e6:
                     # print out float in scientific notation
                     precstr = '{{0:.{}e}}'.format(precision)
+                else:
+                    precstr = '{{0:.{}f}}'.format(precision)  # print out float
 
                 if varerr is not None:
                     if varerr.is_integer():
                         precstre = '{0:.0f}'  # print out an integer
-                else:
-                    precstre = '{{0:.{}f}}'.format(precision)  # print out float
-
-                if varerr is not None:
-                    if abs(varerr) < 1e-6 or abs(varerr) > 1e6:
+                    elif abs(varerr) < 1e-6 or abs(varerr) > 1e6:
                         # print out float in scientific notation
                         precstre = '{{0:.{}e}}'.format(precision)
+                    else:
+                        precstre = '{{0:.{}f}}'.format(precision)  # print out float
 
                 outputdic['value'] = precstr.format(varval)
                 outputdic['error'] = precstre.format(varerr) if varerr is not None else ''


### PR DESCRIPTION
This call was giving the following error:

>   File "psrqpy/search.py", line 2538, in get_ephemeris
>     outputdic['error'] = precstre.format(varerr) if varerr is not None else ''
>                          ^^^^^^^^
> UnboundLocalError: cannot access local variable 'precstre' where it is not associated with a value
> 
> 
when running
```
from psrqpy import QueryATNF
QueryATNF(psrs="J1627+3219").get_ephemeris("J1627+3219")
```
This MR should fix the logic regarding creating the strings to be printed.