### PR TITLE
WIP: Update get_references function to use bibTeX references from webpage

### DIFF
--- a/psrqpy/utils.py
+++ b/psrqpy/utils.py
@@ -1016,6 +1016,10 @@ def get_references(
     >>> import psrqpy
     >>> psrqpy.QueryATNF(checkupdate=True)
 
+    TODO: this need to be rewritten to use the webpage http://www.atnf.csiro.au/research/pulsar/psrcat/psrcat_ref.html
+    which contains the most recent reference in a bibTeX form. ``The psrcat_ref``
+    file no longer contains the most up-to-date references.
+
     Args:
         useads (bool): boolean to set whether to use the python mod:`ads`
             module to get the NASA ADS URL for the references.


### PR DESCRIPTION
Currently, the `get_references` function use the information in the `parcat_ref` file within the [downloadable catalogue tarball](https://www.atnf.csiro.au/research/pulsar/psrcat/downloads/psrcat_pkg.tar.gz). However, this does not appear to contain all the most up-to-date references (see #150), whereas these are on the [references webpage](https://www.atnf.csiro.au/research/pulsar/psrcat/psrcat_ref.html). This PR will attempt to rewrite  `get_references` to use the information directly from the webpage, which are given in a convenient bibTeX format. These often also contain the ADS URL already, which means they will not have to be generated in many cases. I'll probably need to use beautifulsoup and something like [bibtexparser](https://bibtexparser.readthedocs.io/en/main/index.html) for this.