### PR TITLE
Resolves "Reference retrieval no longer works, so temporarily disable test"

### DIFF
--- a/psrqpy/tests/query_test.py
+++ b/psrqpy/tests/query_test.py
@@ -342,6 +342,7 @@ def test_num_columns(query):
     assert len(query.table.columns) == 4
 
 
+@pytest.mark.skip(reason="Reference retrieval is currently no working.")
 def test_get_references(query):
     """
     Test getting the references (without wanting ADS urls).


### PR DESCRIPTION
Closes#160.