### PR TITLE
Feature/discovery date field

### DIFF
--- a/psrqpy/config.py
+++ b/psrqpy/config.py
@@ -80,6 +80,7 @@ PSR_GENERAL['SURVEY'] =   {'ref': False, 'err': False, 'units': None}   # Survey
 # OSURVEY: Surveys that detected the pulsar, encoded as bits in integer
 PSR_GENERAL['OSURVEY'] =  {'ref': False, 'err': False, 'units': None}
 PSR_GENERAL['DATE'] =     {'ref': False, 'err': False, 'units': 'yr'}   # Date of discovery publication
+PSR_GENERAL['POSEPOCH_REF_YEAR'] = {'ref': False, 'err': False, 'units': 'yr'}  # Derived year from POSEPOCH_REF
 # NGLT: Number of glitches observed for the pulsar
 PSR_GENERAL['NGLT'] =     {'ref': False, 'err': False, 'units': None}
 # GLEP: Epoch of glitch (MJD)

--- a/psrqpy/search.py
+++ b/psrqpy/search.py
@@ -712,20 +712,45 @@ class QueryATNF(object):
                 "POSEPOCH_REF"
             ].apply(_ref_year_from_ref)
 
-        if "TYPE_REF" in self.columns:
-            discovery_years = self.__dataframe["TYPE_REF"].apply(_ref_year_min)
-            if "DATE" not in self.columns:
-                self.__dataframe["DATE"] = discovery_years
-            else:
-                if "POSEPOCH_REF_YEAR" in self.columns:
-                    mask = self.__dataframe["DATE"].isna() | (
-                        self.__dataframe["DATE"]
-                        == self.__dataframe["POSEPOCH_REF_YEAR"]
-                    )
-                else:
-                    mask = self.__dataframe["DATE"].isna()
-                if mask.any():
-                    self.__dataframe.loc[mask, "DATE"] = discovery_years[mask]
+        psrj_years = None
+        psrb_years = None
+        if "PSRJ_REF" in self.columns:
+            psrj_years = self.__dataframe["PSRJ_REF"].apply(_ref_year_min)
+        if "PSRB_REF" in self.columns:
+            psrb_years = self.__dataframe["PSRB_REF"].apply(_ref_year_min)
+
+        if psrj_years is None and psrb_years is None:
+            return
+
+        if psrb_years is None:
+            discovery_years = psrj_years
+        elif psrj_years is None:
+            discovery_years = psrb_years
+        else:
+            discovery_years = psrb_years.copy()
+            mask = discovery_years.isna()
+            discovery_years[mask] = psrj_years[mask]
+            mask_both = (~psrb_years.isna()) & (~psrj_years.isna())
+            if mask_both.any():
+                discovery_years[mask_both] = np.minimum(
+                    psrb_years[mask_both], psrj_years[mask_both]
+                )
+
+        has_year = discovery_years.notna()
+
+        if "DATE" not in self.columns:
+            self.__dataframe["DATE"] = discovery_years
+            return
+
+        if has_year.any():
+            self.__dataframe.loc[has_year, "DATE"] = discovery_years[has_year]
+
+        if "POSEPOCH_REF_YEAR" in self.columns:
+            clear_mask = (~has_year) & (
+                self.__dataframe["DATE"] == self.__dataframe["POSEPOCH_REF_YEAR"]
+            )
+            if clear_mask.any():
+                self.__dataframe.loc[clear_mask, "DATE"] = np.nan
 
     def as_array(self):
         """

--- a/psrqpy/search.py
+++ b/psrqpy/search.py
@@ -39,6 +39,45 @@ from .utils import (
 )
 
 
+def _extract_ref_years(refstr):
+    if refstr is None:
+        return []
+    if isinstance(refstr, float) and np.isnan(refstr):
+        return []
+    reftext = str(refstr).strip()
+    if not reftext or reftext == "--" or reftext.lower() == "nan":
+        return []
+
+    years = []
+    for token in re.split(r"[,\s]+", reftext):
+        token = token.strip("[]()")
+        if not token:
+            continue
+        match = re.search(r"(\d{2})(?!.*\d)", token)
+        if match:
+            year = int(match.group(0))
+            if year > 65:
+                year += 1900
+            else:
+                year += 2000
+            years.append(year)
+    return years
+
+
+def _ref_year_from_ref(refstr):
+    years = _extract_ref_years(refstr)
+    if not years:
+        return np.nan
+    return years[0]
+
+
+def _ref_year_min(refstr):
+    years = _extract_ref_years(refstr)
+    if not years:
+        return np.nan
+    return min(years)
+
+
 # set default astropy galactocentric frame values
 # (https://docs.astropy.org/en/latest/coordinates/galactocentric.html)
 if version.parse(astropy.__version__) >= version.parse("4.0"):
@@ -429,6 +468,7 @@ class QueryATNF(object):
         # calculate derived parameters
         self.set_derived()
         self.parse_types()
+        self._ensure_date_fields()
 
         if cache and path_to_db is None:
             # save Query to cache file
@@ -662,8 +702,30 @@ class QueryATNF(object):
                     "_QueryATNF__dataframe"
                 ]
             self._loadfile = fname
+            self._ensure_date_fields()
         except IOError:
             raise IOError("Error reading in pickle")
+
+    def _ensure_date_fields(self):
+        if "POSEPOCH_REF_YEAR" not in self.columns and "POSEPOCH_REF" in self.columns:
+            self.__dataframe["POSEPOCH_REF_YEAR"] = self.__dataframe[
+                "POSEPOCH_REF"
+            ].apply(_ref_year_from_ref)
+
+        if "TYPE_REF" in self.columns:
+            discovery_years = self.__dataframe["TYPE_REF"].apply(_ref_year_min)
+            if "DATE" not in self.columns:
+                self.__dataframe["DATE"] = discovery_years
+            else:
+                if "POSEPOCH_REF_YEAR" in self.columns:
+                    mask = self.__dataframe["DATE"].isna() | (
+                        self.__dataframe["DATE"]
+                        == self.__dataframe["POSEPOCH_REF_YEAR"]
+                    )
+                else:
+                    mask = self.__dataframe["DATE"].isna()
+                if mask.any():
+                    self.__dataframe.loc[mask, "DATE"] = discovery_years[mask]
 
     def as_array(self):
         """

--- a/psrqpy/tests/query_test.py
+++ b/psrqpy/tests/query_test.py
@@ -92,7 +92,7 @@ def test_crab_date_fields(query):
     """
 
     crab = query.get_pulsar('J0534+2200')
-    assert int(crab['DATE'][0]) == 1969
+    assert int(crab['DATE'][0]) == 1968
     assert int(crab['POSEPOCH_REF_YEAR'][0]) == 2023
 
 

--- a/psrqpy/tests/query_test.py
+++ b/psrqpy/tests/query_test.py
@@ -86,6 +86,16 @@ def test_crab(query):
     assert query.get_pulsar('B0531+21')['F0_REF'][0] is not None
 
 
+def test_crab_date_fields(query):
+    """
+    Test that the Crab discovery date and POSEPOCH reference year are preserved.
+    """
+
+    crab = query.get_pulsar('J0534+2200')
+    assert int(crab['DATE'][0]) == 1969
+    assert int(crab['POSEPOCH_REF_YEAR'][0]) == 2023
+
+
 def test_catalogue_shape(query):
     """
     Test the catalogue for shape consistency
@@ -1037,4 +1047,3 @@ def test_name(query):
 
     psr = query.get_pulsar("J1906+1854")  # This pulsar only has a JName
     assert psr["NAME"][0] == psr["JNAME"][0]
-

--- a/psrqpy/tests/query_test.py
+++ b/psrqpy/tests/query_test.py
@@ -174,7 +174,7 @@ def test_save_load_file(tmp_path, query):
     """
 
     # test exception handling
-    testfilebad = '/jkshfdjfd/jkgsdfjkj/kgskfd.jhfd'
+    testfilebad = '/jkshfdjfd/jkgsdfjkj/kgskfs.jhfd'
 
     with pytest.raises(IOError):
         query.save(testfilebad)

--- a/psrqpy/utils.py
+++ b/psrqpy/utils.py
@@ -283,7 +283,7 @@ def get_catalogue(
             if "PEPOCH_REF" in psr.keys():
                 psrlist[i]["POSEPOCH_REF"] = psrlist[i]["PEPOCH_REF"]
 
-        # derive the 'DATE' parameter from the 'POSEPOCH' reference
+        # derive the 'POSEPOCH_REF_YEAR' parameter from the 'POSEPOCH' reference
         # implementation based upon the psrcat v1.66 CLI (definePosEpoch.c:214-242)
         if "POSEPOCH_REF" in psr.keys():
             try:
@@ -294,7 +294,7 @@ def get_catalogue(
                     refyear += 1900
                 else:
                     refyear += 2000
-                psrlist[i]["DATE"] = refyear
+                psrlist[i]["POSEPOCH_REF_YEAR"] = refyear
             except (AttributeError, TypeError):
                 pass
 


### PR DESCRIPTION
**Derive discovery date from PSR references**

Previously the discovery date was derived from the POSEPOCH reference in `psrcat.db` .

This can lead to big mismatches for i.e. the Crab pulsar (J0534+2200). Currently the discovery date is returned as 2023, which corresponds to the most recent POSEPOCH related publication.

Instead, I propose to derive the discovery date from the publication relating to the "PSR" name, which is accurate (1968 for the Crab).

`POSEPOCH_REF_YEAR` may still be queried but the `DATE` now corresponds to the discovery year.

Tests were run on a sample of ~100 pulsars. Testing can be done with

`pytest psrqpy/tests/query_test.py::test_crab_date_fields`
